### PR TITLE
アジェンダ削除機能・通知メール送信実装

### DIFF
--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -1,5 +1,4 @@
 class AgendasController < ApplicationController
-  # before_action :set_agenda, only: %i[show edit update destroy]
 
   def index
     @agendas = Agenda.all
@@ -15,11 +14,22 @@ class AgendasController < ApplicationController
     @agenda.team = Team.friendly.find(params[:team_id])
     current_user.keep_team_id = @agenda.team.id
     if current_user.save && @agenda.save
-      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda') 
+      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda')
     else
       render :new
     end
   end
+
+  def destroy
+    @agenda = Agenda.find(params[:id])
+    if @agenda.destroy && (current_user.id == @agenda.user_id || current_user.id == @agenda.team.owner_id)
+      NoticeMailer.agenda_delete_mail(@agenda.team.members.pluck(:email),current_user,@agenda).deliver
+      redirect_to dashboard_path, notice: "agenda「#{@agenda.title}」を削除しました"
+    else
+      redirect_to dashboard_path, notice: "agenda「#{@agenda.title}」を削除できませんでした"
+    end
+  end
+
 
   private
 

--- a/app/mailers/notice_mailer.rb
+++ b/app/mailers/notice_mailer.rb
@@ -1,0 +1,10 @@
+class NoticeMailer < ApplicationMailer
+  default from: 'from@example.com'
+
+  def agenda_delete_mail(email,user,agenda)
+    @email = email
+    @user = user
+    @agenda = agenda
+    mail to: @email, subject: 'agenda削除のお知らせ'
+  end
+end

--- a/app/views/notice_mailer/agenda_delete_mail.html.erb
+++ b/app/views/notice_mailer/agenda_delete_mail.html.erb
@@ -1,1 +1,1 @@
-<h1><%= "チーム：#{@agenda.team.name}のagenda：#{@agenda.title}を#{@user.email}が削除しました" %></h1>
+<h1><%= "チーム：#{@agenda.team.name}のアジェンダ：#{@agenda.title}を#{@user.email}が削除しました" %></h1>

--- a/app/views/notice_mailer/agenda_delete_mail.html.erb
+++ b/app/views/notice_mailer/agenda_delete_mail.html.erb
@@ -1,0 +1,1 @@
+<h1><%= "チーム：#{@agenda.team.name}のagenda：#{@agenda.title}を#{@user.email}が削除しました" %></h1>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -30,10 +30,13 @@
       <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
         <% @working_team.agendas.each do |agenda| %>
           <li class="nav-item has-treeview menu-open">
-            <a href="#" class="nav-link">
+            <a href="#" class="nav-link" style="position:relative">
               <i class="fa fa-circle-o nav-icon"></i>
               <p>
                 <%= agenda.title %>
+                <% if current_user.id == agenda.user_id || current_user.id == @working_team.owner_id %>
+                <object style="position:absolute; right:30px; display:inline; vertical-align: middle;"><%= link_to '削除', agenda_path(agenda), method: :delete, class: 'btn-sm btn-danger' %></object>
+                <% end %>
                 <i class="right fa fa-angle-left"></i>
               </p>
             </a>


### PR DESCRIPTION
#1 
- [x] AgendasControllerのdestroyアクションを追加し、そこに機能追加する

- [x] Agendaの名前の右の部分に削除ボタンを作成し、そのボタンを押すとそのAgendaが削除される

- [x] Agendaに紐づいているarticleも一緒に削除される

- [x] Agendaを削除できるのは、そのAgendaの作者もしくはそのAgendaに紐づいているTeamの作者（オーナー）のみ

- [x] Agendaが削除されると、そのAgendaに紐づいているTeamに所属しているユーザー全員に通知メールが飛ぶ

- [x] 情報処理が完了した後はDashBoardに飛ぶ

その他、アプリケーションの挙動に不審な点やエラーがないこと